### PR TITLE
Refactor shared views to reduce duplication

### DIFF
--- a/cataclysm/adminflow/views.py
+++ b/cataclysm/adminflow/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
+from cataclysm.view_helpers import make_index_view
 
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the root index.")
+index = make_index_view("root")

--- a/cataclysm/armor/views.py
+++ b/cataclysm/armor/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
+from cataclysm.view_helpers import make_index_view
 
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the armor index.")
+index = make_index_view("armor")

--- a/cataclysm/cataclysm/view_helpers.py
+++ b/cataclysm/cataclysm/view_helpers.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+
+def make_index_view(app_label: str) -> Callable[[HttpRequest], HttpResponse]:
+    """Return a view that renders the default index message for an app."""
+    message = f"Hello, world. You're at the {app_label} index."
+
+    def view(request: HttpRequest) -> HttpResponse:
+        return HttpResponse(message)
+
+    return view

--- a/cataclysm/events/views.py
+++ b/cataclysm/events/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
+from cataclysm.view_helpers import make_index_view
 
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the events index.")
+index = make_index_view("events")

--- a/cataclysm/factions/views.py
+++ b/cataclysm/factions/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
+from cataclysm.view_helpers import make_index_view
 
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the factions index.")
+index = make_index_view("factions")

--- a/cataclysm/landing/views.py
+++ b/cataclysm/landing/views.py
@@ -1,8 +1,8 @@
 from django.shortcuts import render
 
+
 def landing_page(request):
+    context = {}
     if request.user.is_authenticated:
-        username = request.user.username
-        return render(request, 'landing_page.html', {'username': username})
-    else:
-        return render(request, 'landing_page.html')
+        context['username'] = request.user.username
+    return render(request, 'landing_page.html', context)

--- a/cataclysm/party/views.py
+++ b/cataclysm/party/views.py
@@ -1,50 +1,48 @@
 from django.shortcuts import render
-
-
-
-from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
-from django.views.generic import ListView, DetailView, CreateView, UpdateView
-from .models import Party
+from django.views.generic import CreateView, DetailView, ListView, UpdateView
+
 from .forms import PartyForm
+from .models import Party
 
 
 class PartyListView(ListView):
-	model = Party
-	template_name = 'party/party_index.html'
-	context_object_name = 'party_list'
-    
-	def get_queryset(self):
-		qs = super().get_queryset()
-		order_by = self.request.GET.get('order_by')
-		if order_by:
-			qs = qs.order_by(order_by)
-		return qs
+    model = Party
+    template_name = 'party/party_index.html'
+    context_object_name = 'party_list'
+
+    def get_queryset(self):
+        qs = super().get_queryset()
+        order_by = self.request.GET.get('order_by')
+        if order_by:
+            qs = qs.order_by(order_by)
+        return qs
 
 
 class PartyDetailView(DetailView):
-	model = Party
-	template_name = 'party/party.html'
-	context_object_name = 'current_party'
+    model = Party
+    template_name = 'party/party.html'
+    context_object_name = 'current_party'
 
 
 class PartyCreateView(CreateView):
-	model = Party
-	form_class = PartyForm
-	template_name = 'party/party_form.html'
-    
-	def get_success_url(self):
-		return reverse_lazy('party_page', kwargs={'pk': self.object.pk})
+    model = Party
+    form_class = PartyForm
+    template_name = 'party/party_form.html'
+
+    def get_success_url(self):
+        return reverse_lazy('party_page', kwargs={'pk': self.object.pk})
 
 
 class PartyUpdateView(UpdateView):
-	model = Party
-	form_class = PartyForm
-	template_name = 'party/party_form.html'
-    
-	def get_success_url(self):
-		return reverse_lazy('party_page', kwargs={'pk': self.object.pk})
+    model = Party
+    form_class = PartyForm
+    template_name = 'party/party_form.html'
+
+    def get_success_url(self):
+        return reverse_lazy('party_page', kwargs={'pk': self.object.pk})
+
 
 def add_party_images(request, pk):
-	# Placeholder for add images logic
-	return render(request, 'party/party.html', {})
+    # Placeholder for add images logic
+    return render(request, 'party/party.html', {})

--- a/cataclysm/weapons/views.py
+++ b/cataclysm/weapons/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
+from cataclysm.view_helpers import make_index_view
 
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the weapons index.")
+index = make_index_view("weapons")

--- a/cataclysm/worlds/views.py
+++ b/cataclysm/worlds/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
+from cataclysm.view_helpers import make_index_view
 
-
-def index(request):
-    return HttpResponse("Hello, world. You're at the worlds index.")
+index = make_index_view("worlds")


### PR DESCRIPTION
## Summary
- add a reusable helper for the simple index views used across multiple apps
- refactor the armor, events, factions, adminflow, weapons, and worlds apps to use the shared helper
- streamline the landing and party views to remove redundant logic and imports

## Testing
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'crispy_forms')*


------
https://chatgpt.com/codex/tasks/task_e_68d3576ab7148323b39ae1138a088133