### PR TITLE
Restyle add-object forms with LCARS layout

### DIFF
--- a/cataclysm/armor/templates/armor/add_object.html
+++ b/cataclysm/armor/templates/armor/add_object.html
@@ -1,13 +1,70 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:700px; margin-top:24px;">
-  <h1>Add Armor</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Armor</h1>
+      <p class="lcars-form__subtitle">Catalog defensive gear with a streamlined LCARS workflow.</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save Armor</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Classification</h2>
+          {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+          {% if form|has_field:'armor_type' %}{{ form.armor_type|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Protection Ratings</h2>
+          {% if form|has_field:'base_armor_class' %}{{ form.base_armor_class|as_crispy_field }}{% endif %}
+          {% if form|has_field:'max_dexterity_bonus' %}{{ form.max_dexterity_bonus|as_crispy_field }}{% endif %}
+          {% if form|has_field:'armor_check_penalty' %}{{ form.armor_check_penalty|as_crispy_field }}{% endif %}
+          {% if form|has_field:'speed_penalty' %}{{ form.speed_penalty|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Logistics</h2>
+          {% if form|has_field:'weight' %}{{ form.weight|as_crispy_field }}{% endif %}
+          {% if form|has_field:'hidden' %}{{ form.hidden|as_crispy_field }}{% endif %}
+        </section>
+
+        {% if form|has_field:'dynamic_tags' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Dynamic Tags</h2>
+            {{ form.dynamic_tags|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        {% if form|has_field:'description' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Field Notes</h2>
+            {{ form.description|as_crispy_field }}
+          </section>
+        {% endif %}
+      </div>
+    {% else %}
+      <p>Armor creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Armor</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/cataclysm/cataclysm/templatetags/custom_filters.py
+++ b/cataclysm/cataclysm/templatetags/custom_filters.py
@@ -15,3 +15,12 @@ def isboolean(value):
 @register.filter(name='sort_by_key')
 def sort_by_key(value, key):
     return sorted(value, key=lambda x: x[key])
+
+
+@register.filter(name='has_field')
+def has_field(form, field_name):
+    """Return True if a form contains a bound field with the given name."""
+    try:
+        return field_name in form.fields
+    except AttributeError:
+        return False

--- a/cataclysm/events/templates/events/add_object.html
+++ b/cataclysm/events/templates/events/add_object.html
@@ -1,13 +1,76 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:900px; margin-top:24px;">
-  <h1>Add Event</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Event</h1>
+      <p class="lcars-form__subtitle">Log a pivotal happening in the campaign timeline.</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save Event</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Overview</h2>
+          {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+          {% if form|has_field:'event_type' %}{{ form.event_type|as_crispy_field }}{% endif %}
+          {% if form|has_field:'location' %}{{ form.location|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Participants</h2>
+          {% if form|has_field:'people' %}{{ form.people|as_crispy_field }}{% endif %}
+          {% if form|has_field:'factions' %}{{ form.factions|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Worlds & Species</h2>
+          {% if form|has_field:'species' %}{{ form.species|as_crispy_field }}{% endif %}
+          {% if form|has_field:'worlds' %}{{ form.worlds|as_crispy_field }}{% endif %}
+        </section>
+
+        {% if form|has_field:'image' %}
+          <section class="lcars-form__section">
+            <h2 class="lcars-form__section-title">Media</h2>
+            {{ form.image|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        {% if form|has_field:'description' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Mission Log</h2>
+            {{ form.description|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        {% if form|has_field:'hidden' %}
+          <section class="lcars-form__section">
+            <h2 class="lcars-form__section-title">Visibility</h2>
+            {{ form.hidden|as_crispy_field }}
+          </section>
+        {% endif %}
+      </div>
+    {% else %}
+      <p>Event creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Event</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/cataclysm/factions/templates/factions/add_object.html
+++ b/cataclysm/factions/templates/factions/add_object.html
@@ -1,13 +1,64 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:900px; margin-top:24px;">
-  <h1>Add Faction</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Faction</h1>
+      <p class="lcars-form__subtitle">Define the organization and its influence.</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save Faction</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Identity</h2>
+          {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+          {% if form|has_field:'image' %}{{ form.image|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section lcars-form__section--full">
+          <h2 class="lcars-form__section-title">Mandate</h2>
+          {% if form|has_field:'description' %}{{ form.description|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Membership</h2>
+          {% if form|has_field:'people' %}{{ form.people|as_crispy_field }}{% endif %}
+          {% if form|has_field:'species' %}{{ form.species|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Holdings</h2>
+          {% if form|has_field:'worlds' %}{{ form.worlds|as_crispy_field }}{% endif %}
+          {% if form|has_field:'events' %}{{ form.events|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Visibility</h2>
+          {% if form|has_field:'hidden' %}{{ form.hidden|as_crispy_field }}{% endif %}
+        </section>
+      </div>
+    {% else %}
+      <p>Faction creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Faction</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/cataclysm/landing/templates/base.html
+++ b/cataclysm/landing/templates/base.html
@@ -6,6 +6,7 @@
     <title>{% block title %}Cataclysm{% endblock %}</title>
     <link rel="stylesheet" href="{% static 'css/default.css' %}">
     <link rel="stylesheet" href="{% static 'css/lcars.css' %}">
+    <link rel="stylesheet" href="{% static 'css/lcars-form.css' %}">
 </head>
 <body>
     {% include 'navbar.html' %}

--- a/cataclysm/people/templates/add_object.html
+++ b/cataclysm/people/templates/add_object.html
@@ -1,58 +1,134 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="sci-fi-form-container">
-    <h1 style="text-align:center; letter-spacing: 0.12em; color: #0ff; text-shadow: 0 0 10px #0ff, 0 0 2px #fff; font-size:2.2rem;">Add New Person</h1>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        <div class="sci-fi-form-grid">
-            <div class="sci-fi-form-section">
-                <h4 style="color:#00f0ff; font-family:'Orbitron',sans-serif; font-size:1.1rem; margin-bottom:10px;">General</h4>
-                {{ form.name|as_crispy_field }}
-                {{ form.age|as_crispy_field }}
-                {{ form.sex|as_crispy_field }}
-                {{ form.species|as_crispy_field }}
-                {{ form.faction|as_crispy_field }}
-                {{ form.rank|as_crispy_field }}
-                {{ form.position|as_crispy_field }}
-                {{ form.location|as_crispy_field }}
+<section class="lcars-panel lcars-form">
+  {% if form_mode == 'person' %}
+    <div class="lcars-form__header">
+      <span class="lcars-form__chip" aria-hidden="true"></span>
+      <div>
+        <h1 class="lcars-form__title">Add Crew Member</h1>
+        <p class="lcars-form__subtitle">Document a new operative for the Cataclysm roster.</p>
+      </div>
+    </div>
+  {% elif form_mode == 'person_image' %}
+    <div class="lcars-form__header">
+      <span class="lcars-form__chip" aria-hidden="true"></span>
+      <div>
+        <h1 class="lcars-form__title">Attach Visual Record</h1>
+        <p class="lcars-form__subtitle">Upload supporting imagery for an existing crew member.</p>
+      </div>
+    </div>
+  {% else %}
+    <div class="lcars-form__header">
+      <span class="lcars-form__chip" aria-hidden="true"></span>
+      <div>
+        <h1 class="lcars-form__title">Add Record</h1>
+        <p class="lcars-form__subtitle">Provide the details below to expand the database.</p>
+      </div>
+    </div>
+  {% endif %}
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
+    {% csrf_token %}
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="lcars-form__errors">
+        {{ form.non_field_errors }}
+      </div>
+    {% endif %}
+
+    {% if form_mode == 'person' %}
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Profile</h2>
+          {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+          {% if form|has_field:'age' %}{{ form.age|as_crispy_field }}{% endif %}
+          {% if form|has_field:'sex' %}{{ form.sex|as_crispy_field }}{% endif %}
+          {% if form|has_field:'species' %}{{ form.species|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Assignment</h2>
+          {% if form|has_field:'faction' %}{{ form.faction|as_crispy_field }}{% endif %}
+          {% if form|has_field:'rank' %}{{ form.rank|as_crispy_field }}{% endif %}
+          {% if form|has_field:'position' %}{{ form.position|as_crispy_field }}{% endif %}
+          {% if form|has_field:'location' %}{{ form.location|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Equipment</h2>
+          {% if form|has_field:'weapons' %}{{ form.weapons|as_crispy_field }}{% endif %}
+          {% if form|has_field:'armors' %}{{ form.armors|as_crispy_field }}{% endif %}
+        </section>
+
+        {% if form|has_field:'traits' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Traits</h2>
+            {{ form.traits|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        {% if form|has_field:'bio' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Background</h2>
+            {{ form.bio|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Visual Records</h2>
+          {% if form|has_field:'image' %}{{ form.image|as_crispy_field }}{% endif %}
+          {% if form|has_field:'additional_images' %}{{ form.additional_images|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Attributes</h2>
+          {% if form|has_field:'stats' %}{{ form.stats|as_crispy_field }}{% endif %}
+          {% if form|has_field:'skills' %}
+            <div class="lcars-form__inline">
+              {{ form.skills|as_crispy_field }}
+              <button type="button" class="lcars-btn" data-toggle="modal" data-target="#selectSkillsModal">Browse Skillsets</button>
             </div>
-            <div class="sci-fi-form-section">
-                <h4 style="color:#00f0ff; font-family:'Orbitron',sans-serif; font-size:1.1rem; margin-bottom:10px;">Equipment & Bio</h4>
-                {{ form.weapons|as_crispy_field }}
-                {{ form.armors|as_crispy_field }}
-                {{ form.bio|as_crispy_field }}
-                {{ form.image|as_crispy_field }}
-                {{ form.additional_images|as_crispy_field }}
-            </div>
-            <div class="sci-fi-form-section">
-                <h4 style="color:#00f0ff; font-family:'Orbitron',sans-serif; font-size:1.1rem; margin-bottom:10px;">Attributes & Skills</h4>
-                {{ form.stats|as_crispy_field }}
-                                <div style="display: flex; align-items: center; gap: 1em;">
-                                    {{ form.skills|as_crispy_field }}
-                                    <button type="button" class="btn btn-info" data-toggle="modal" data-target="#selectSkillsModal" style="margin-top: 0.5em;">Select Skills</button>
-                                </div>
-                {{ form.tactician|as_crispy_field }}
-                {{ form.medical|as_crispy_field }}
-                {{ form.scientist|as_crispy_field }}
-                {{ form.engineer|as_crispy_field }}
-                {{ form.strong|as_crispy_field }}
-                {{ form.tough|as_crispy_field }}
-                {{ form.agile|as_crispy_field }}
-                {{ form.stealthy|as_crispy_field }}
-                {{ form.cybernetic|as_crispy_field }}
-                {{ form.leader|as_crispy_field }}
-                {{ form.genius|as_crispy_field }}
-                {{ form.psychic|as_crispy_field }}
-                {{ form.flier|as_crispy_field }}
-                {{ form.mutant|as_crispy_field }}
-            </div>
-        </div>
-        <div style="text-align:center; margin-top: 2.5em;">
-            <button type="submit" class="btn btn-primary">Engage</button>
-        </div>
-        {{ form.hidden|as_crispy_field }}
-    </form>
-</div>
+          {% endif %}
+          {% if form|has_field:'hidden' %}{{ form.hidden|as_crispy_field }}{% endif %}
+        </section>
+      </div>
+    {% elif form_mode == 'person_image' %}
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Link</h2>
+          {% if form|has_field:'linked_person' %}{{ form.linked_person|as_crispy_field }}{% endif %}
+        </section>
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Upload</h2>
+          {% if form|has_field:'additional_image' %}{{ form.additional_image|as_crispy_field }}{% endif %}
+        </section>
+        <section class="lcars-form__section lcars-form__section--full">
+          <h2 class="lcars-form__section-title">Caption</h2>
+          {% if form|has_field:'description' %}{{ form.description|as_crispy_field }}{% endif %}
+        </section>
+      </div>
+    {% else %}
+      <div class="lcars-form__grid">
+        {% for field in form.visible_fields %}
+          <section class="lcars-form__section">
+            {{ field|as_crispy_field }}
+          </section>
+        {% endfor %}
+      </div>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Record</button>
+    </div>
+  </form>
+</section>
+
+{% if form_mode == 'person' %}
+  {% include 'modals/skills_modal.html' %}
+  {% include 'people/skills_modal_script.html' %}
+{% endif %}
 {% endblock %}

--- a/cataclysm/people/views.py
+++ b/cataclysm/people/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import redirect, render
 from django.http import HttpResponse  # Import HttpResponse class
 from people.forms import PersonForm, PersonImageForm
-from people.models import Person, Skillset
+from people.models import Person, Skillset, Trait
 
 
 def index(request):
@@ -45,7 +45,15 @@ def add_person(request):
         for field in skill_fields:
             value = getattr(skillset, field, None)
             skills.append({'id': f'{skillset.id}_{field}', 'name': field.replace('_', ' ').title(), 'value': value})
-    return render(request, 'add_object.html', {'form': form, 'skills': skills})
+    return render(
+        request,
+        'add_object.html',
+        {
+            'form': form,
+            'skills': skills,
+            'form_mode': 'person',
+        },
+    )
 
 def edit_person(request, id):
     person = Person.objects.get(id=id)
@@ -67,7 +75,15 @@ def edit_person(request, id):
         for field in skill_fields:
             value = getattr(skillset, field, None)
             skills.append({'id': f'{skillset.id}_{field}', 'name': field.replace('_', ' ').title(), 'value': value})
-    return render(request, 'add_object.html', {'form': form, 'skills': skills})
+    return render(
+        request,
+        'add_object.html',
+        {
+            'form': form,
+            'skills': skills,
+            'form_mode': 'person',
+        },
+    )
 
 def delete_person(request, id):
     person = Person.objects.get(id=id)
@@ -85,4 +101,12 @@ def add_images(request, id):
         form = PersonImageForm(initial={'linked_person': person})
 
     # Always pass skills, even if empty
-    return render(request, 'add_object.html', {'form': form, 'skills': []})
+    return render(
+        request,
+        'add_object.html',
+        {
+            'form': form,
+            'skills': [],
+            'form_mode': 'person_image',
+        },
+    )

--- a/cataclysm/ships/templates/ships/add_object.html
+++ b/cataclysm/ships/templates/ships/add_object.html
@@ -1,13 +1,43 @@
 {% extends 'base.html' %}
 {% load crispy_forms_tags %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:1000px; margin-top:24px;">
-  <h1>Add Starship</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Starship</h1>
+      <p class="lcars-form__subtitle">Commission a new vessel into the fleet registry.</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save Starship</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section lcars-form__section--full">
+          <h2 class="lcars-form__section-title">Vessel Profile</h2>
+          {% for field in form.visible_fields %}
+            {{ field|as_crispy_field }}
+          {% endfor %}
+        </section>
+      </div>
+    {% else %}
+      <p>Starship creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Starship</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/cataclysm/species/templates/add_object.html
+++ b/cataclysm/species/templates/add_object.html
@@ -1,13 +1,1 @@
-{% extends 'base.html' %}
-{% load crispy_forms_tags %}
-{% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:900px; margin-top:24px;">
-	<h1>Add Species</h1>
-	<form method="post" enctype="multipart/form-data">
-		{% csrf_token %}
-		{{ form|crispy }}
-		<button type="submit" class="btn btn-primary">Save Species</button>
-	</form>
-</div>
-{% endblock %}
+{% extends 'species/add_object.html' %}

--- a/cataclysm/species/templates/species/add_object.html
+++ b/cataclysm/species/templates/species/add_object.html
@@ -1,60 +1,102 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="lcars-panel">
-    <div class="sci-fi-form-container">
-    <h1 style="text-align:center; letter-spacing: 0.12em; color: #0ff; text-shadow: 0 0 10px #0ff, 0 0 2px #fff; font-size:2.2rem;">Add New Species</h1>
-    <form method="post" enctype="multipart/form-data">
-        {% csrf_token %}
-        <div class="sci-fi-form-grid" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 2.5em 3em; align-items: start;">
-            <div class="sci-fi-form-section" style="grid-column: 1;">
-                <h4 style="color:#00f0ff; font-family:'Orbitron',sans-serif; font-size:1.1rem; margin-bottom:10px;">General</h4>
-                {{ form.name|as_crispy_field }}
-                {{ form.home_world|as_crispy_field }}
-                {{ form.society|as_crispy_field }}
-                {{ form.accord_status|as_crispy_field }}
-                {{ form.size|as_crispy_field }}
-                {{ form.type|as_crispy_field }}
-                {{ form.air|as_crispy_field }}
-                {{ form.gravity|as_crispy_field }}
-            </div>
-            <div class="sci-fi-form-section" style="grid-column: 2;">
-                <h4 style="color:#00f0ff; font-family:'Orbitron',sans-serif; font-size:1.1rem; margin-bottom:10px;">Biology & Society</h4>
-                {{ form.background|as_crispy_field }}
-                {{ form.sociology|as_crispy_field }}
-                {{ form.physiology|as_crispy_field }}
-                {{ form.racial_traits|as_crispy_field }}
-                {{ form.reproduction_method|as_crispy_field }}
-                {{ form.hours_of_sleep|as_crispy_field }}
-                {{ form.days_without_food|as_crispy_field }}
-                {{ form.days_without_water|as_crispy_field }}
-                {{ form.locomotion_method|as_crispy_field }}
-            </div>
-            <div class="sci-fi-form-section" style="grid-column: 3;">
-                <h4 style="color:#00f0ff; font-family:'Orbitron',sans-serif; font-size:1.1rem; margin-bottom:10px;">Abilities & Traits</h4>
-                {{ form.strength_rating|as_crispy_field }}
-                {{ form.toughness_rating|as_crispy_field }}
-                {{ form.speed_rating|as_crispy_field }}
-                {{ form.intelligence_rating|as_crispy_field }}
-                {{ form.natural_weapons|as_crispy_field }}
-                {{ form.natural_armor|as_crispy_field }}
-                {{ form.can_fly|as_crispy_field }}
-                {{ form.aquatic|as_crispy_field }}
-                {{ form.amphibious|as_crispy_field }}
-                {{ form.telepathic|as_crispy_field }}
-                {{ form.psionic|as_crispy_field }}
-                {{ form.special_abilities|as_crispy_field }}
-                {{ form.image|as_crispy_field }}
-                {{ form.hidden|as_crispy_field }}
-            </div>
-        </div>
-        <div style="text-align:center; margin-top: 2.5em;">
-            <button type="submit" class="btn btn-primary" style="background: linear-gradient(90deg, #0ff 0%, #09f 100%); border: none; color: #222; font-weight: bold; font-size: 1.2em; padding: 0.5em 2em; border-radius: 0.5em; box-shadow: 0 0 12px #0ff; transition: background 0.3s;">Engage</button>
-        </div>
-    </form>
-    <p style="text-align:center; margin-top:2em; color:#0ff; font-size:1.1em; letter-spacing:0.05em;">"To boldly go where no species has gone before..."</p>
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Species</h1>
+      <p class="lcars-form__subtitle">Capture the traits of a new civilization for the LCARS archive.</p>
     </div>
-</div>
-<!-- CSS moved to sci-fi-form.css -->
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
+    {% csrf_token %}
+    {% for hidden_field in form.hidden_fields %}
+      {{ hidden_field }}
+    {% endfor %}
+
+    {% if form.non_field_errors %}
+      <div class="lcars-form__errors">
+        {{ form.non_field_errors }}
+      </div>
+    {% endif %}
+
+    <div class="lcars-form__grid">
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Identity</h2>
+        {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+        {% if form|has_field:'type' %}{{ form.type|as_crispy_field }}{% endif %}
+        {% if form|has_field:'size' %}{{ form.size|as_crispy_field }}{% endif %}
+        {% if form|has_field:'accord_status' %}{{ form.accord_status|as_crispy_field }}{% endif %}
+        {% if form|has_field:'home_world' %}{{ form.home_world|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Environment</h2>
+        {% if form|has_field:'air' %}{{ form.air|as_crispy_field }}{% endif %}
+        {% if form|has_field:'gravity' %}{{ form.gravity|as_crispy_field }}{% endif %}
+        {% if form|has_field:'locomotion_method' %}{{ form.locomotion_method|as_crispy_field }}{% endif %}
+        {% if form|has_field:'reproduction_method' %}{{ form.reproduction_method|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Sustenance</h2>
+        {% if form|has_field:'hours_of_sleep' %}{{ form.hours_of_sleep|as_crispy_field }}{% endif %}
+        {% if form|has_field:'days_without_food' %}{{ form.days_without_food|as_crispy_field }}{% endif %}
+        {% if form|has_field:'days_without_water' %}{{ form.days_without_water|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section lcars-form__section--full">
+        <h2 class="lcars-form__section-title">Society</h2>
+        {% if form|has_field:'society' %}{{ form.society|as_crispy_field }}{% endif %}
+        {% if form|has_field:'background' %}{{ form.background|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section lcars-form__section--full">
+        <h2 class="lcars-form__section-title">Physiology</h2>
+        {% if form|has_field:'physiology' %}{{ form.physiology|as_crispy_field }}{% endif %}
+        {% if form|has_field:'racial_traits' %}{{ form.racial_traits|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Adaptations</h2>
+        {% if form|has_field:'natural_weapons' %}{{ form.natural_weapons|as_crispy_field }}{% endif %}
+        {% if form|has_field:'natural_armor' %}{{ form.natural_armor|as_crispy_field }}{% endif %}
+        {% if form|has_field:'special_abilities' %}{{ form.special_abilities|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Capabilities</h2>
+        {% if form|has_field:'strength_rating' %}{{ form.strength_rating|as_crispy_field }}{% endif %}
+        {% if form|has_field:'toughness_rating' %}{{ form.toughness_rating|as_crispy_field }}{% endif %}
+        {% if form|has_field:'speed_rating' %}{{ form.speed_rating|as_crispy_field }}{% endif %}
+        {% if form|has_field:'intelligence_rating' %}{{ form.intelligence_rating|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Traits</h2>
+        <div class="lcars-form__inline">
+          {% if form|has_field:'can_fly' %}{{ form.can_fly|as_crispy_field }}{% endif %}
+          {% if form|has_field:'aquatic' %}{{ form.aquatic|as_crispy_field }}{% endif %}
+        </div>
+        <div class="lcars-form__inline">
+          {% if form|has_field:'amphibious' %}{{ form.amphibious|as_crispy_field }}{% endif %}
+          {% if form|has_field:'telepathic' %}{{ form.telepathic|as_crispy_field }}{% endif %}
+        </div>
+        {% if form|has_field:'psionic' %}{{ form.psionic|as_crispy_field }}{% endif %}
+      </section>
+
+      <section class="lcars-form__section">
+        <h2 class="lcars-form__section-title">Records</h2>
+        {% if form|has_field:'image' %}{{ form.image|as_crispy_field }}{% endif %}
+        {% if form|has_field:'hidden' %}{{ form.hidden|as_crispy_field }}{% endif %}
+      </section>
+    </div>
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Species</button>
+    </div>
+  </form>
+</section>
 {% endblock %}

--- a/cataclysm/static/css/lcars-form.css
+++ b/cataclysm/static/css/lcars-form.css
@@ -1,0 +1,171 @@
+.lcars-form {
+  max-width: 1100px;
+  margin: 2.5rem auto;
+  padding: clamp(1.5rem, 2.5vw, 2.75rem);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(5, 16, 24, 0.65));
+  border: 3px solid var(--lcars-panel, #ff8f00);
+  border-radius: 1.4rem;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+}
+
+.lcars-form__header {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-bottom: 1.75rem;
+  flex-wrap: wrap;
+}
+
+.lcars-form__chip {
+  width: 76px;
+  height: 38px;
+  border-radius: 1.8rem;
+  background: linear-gradient(120deg, var(--lcars-panel, #ff8f00), var(--lcars-panel-dark, #cc6f00));
+  box-shadow: 0 0 18px rgba(255, 143, 0, 0.4);
+}
+
+.lcars-form__title {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.8vw, 2.2rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lcars-form__subtitle {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: clamp(0.9rem, 2vw, 1.05rem);
+  letter-spacing: 0.04em;
+}
+
+.lcars-form__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.lcars-form__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(1.3rem, 2.5vw, 2rem);
+}
+
+.lcars-form__section {
+  background: rgba(4, 24, 36, 0.55);
+  border-radius: 1.1rem;
+  padding: clamp(1rem, 2vw, 1.4rem);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  position: relative;
+}
+
+.lcars-form__section::before {
+  content: '';
+  position: absolute;
+  top: 1rem;
+  left: -1.6rem;
+  width: 1rem;
+  height: 2.6rem;
+  border-radius: 0.8rem;
+  background: var(--lcars-accent, #ff66cc);
+  box-shadow: 0 0 12px rgba(255, 102, 204, 0.35);
+}
+
+.lcars-form__section-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--lcars-accent-2, #00c8ff);
+}
+
+.lcars-form__section--full {
+  grid-column: 1 / -1;
+}
+
+.lcars-form__section p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.lcars-form input,
+.lcars-form select,
+.lcars-form textarea {
+  width: 100%;
+  background: rgba(6, 18, 28, 0.82);
+  border: 1.5px solid var(--lcars-accent-2, #00c8ff);
+  border-radius: 0.5rem;
+  color: var(--lcars-text, #ffffff);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.95rem;
+  box-shadow: inset 0 0 12px rgba(0, 200, 255, 0.18);
+}
+
+.lcars-form textarea {
+  min-height: 140px;
+}
+
+.lcars-form label {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.82);
+}
+
+.lcars-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding-top: 0.5rem;
+}
+
+.lcars-form__submit {
+  padding: 0.65rem 2.4rem;
+  font-size: 1rem;
+  letter-spacing: 0.08em;
+}
+
+.lcars-form__errors {
+  background: rgba(255, 102, 204, 0.12);
+  border: 1px solid rgba(255, 102, 204, 0.45);
+  border-radius: 0.8rem;
+  padding: 0.85rem 1rem;
+}
+
+.lcars-form__inline {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.lcars-form__inline .lcars-btn {
+  margin-top: 0.35rem;
+}
+
+@media (max-width: 900px) {
+  .lcars-form {
+    margin: 1.8rem auto;
+    padding: clamp(1.2rem, 4vw, 2rem);
+  }
+  .lcars-form__section::before {
+    left: -1.2rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .lcars-form__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .lcars-form__chip {
+    width: 64px;
+    height: 30px;
+  }
+  .lcars-form__section::before {
+    display: none;
+  }
+}

--- a/cataclysm/vehicles/templates/vehicles/add_object.html
+++ b/cataclysm/vehicles/templates/vehicles/add_object.html
@@ -1,13 +1,43 @@
 {% extends 'base.html' %}
 {% load crispy_forms_tags %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:900px; margin-top:24px;">
-  <h1>Add Vehicle</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Vehicle</h1>
+      <p class="lcars-form__subtitle">Register a new ground or atmospheric craft.</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save Vehicle</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section lcars-form__section--full">
+          <h2 class="lcars-form__section-title">Vehicle Profile</h2>
+          {% for field in form.visible_fields %}
+            {{ field|as_crispy_field }}
+          {% endfor %}
+        </section>
+      </div>
+    {% else %}
+      <p>Vehicle creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Vehicle</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/cataclysm/weapons/templates/weapons/add_object.html
+++ b/cataclysm/weapons/templates/weapons/add_object.html
@@ -1,13 +1,72 @@
 {% extends "base.html" %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:900px; margin-top:20px;">
-  <h1>Add Weapon</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add Weapon</h1>
+      <p class="lcars-form__subtitle">Record the specifications for a new arsenal entry.</p>
+    </div>
+  </div>
+
+  <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save Weapon</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Classification</h2>
+          {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+          {% if form|has_field:'weapon_type' %}{{ form.weapon_type|as_crispy_field }}{% endif %}
+          {% if form|has_field:'secondary_weapon' %}{{ form.secondary_weapon|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Combat Profile</h2>
+          {% if form|has_field:'damage' %}{{ form.damage|as_crispy_field }}{% endif %}
+          {% if form|has_field:'critical' %}{{ form.critical|as_crispy_field }}{% endif %}
+          {% if form|has_field:'range_increment' %}{{ form.range_increment|as_crispy_field }}{% endif %}
+          {% if form|has_field:'usage' %}{{ form.usage|as_crispy_field }}{% endif %}
+          {% if form|has_field:'capacity' %}{{ form.capacity|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Logistics</h2>
+          {% if form|has_field:'weight' %}{{ form.weight|as_crispy_field }}{% endif %}
+          {% if form|has_field:'hidden' %}{{ form.hidden|as_crispy_field }}{% endif %}
+        </section>
+
+        {% if form|has_field:'special_properties' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Special Systems</h2>
+            {{ form.special_properties|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        {% if form|has_field:'description' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Field Notes</h2>
+            {{ form.description|as_crispy_field }}
+          </section>
+        {% endif %}
+      </div>
+    {% else %}
+      <p>Weapon creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save Weapon</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}

--- a/cataclysm/worlds/templates/worlds/add_object.html
+++ b/cataclysm/worlds/templates/worlds/add_object.html
@@ -1,13 +1,72 @@
 {% extends 'base.html' %}
-{% load crispy_forms_tags %}
+{% load crispy_forms_tags custom_filters %}
 {% block content %}
-<link rel="stylesheet" href="/static/css/sci-fi-form.css">
-<div class="container sci-fi-form-container" style="max-width:900px; margin-top:24px;">
-  <h1>Add World</h1>
-  <form method="post" enctype="multipart/form-data">
+<section class="lcars-panel lcars-form">
+  <div class="lcars-form__header">
+    <span class="lcars-form__chip" aria-hidden="true"></span>
+    <div>
+      <h1 class="lcars-form__title">Add World</h1>
+      <p class="lcars-form__subtitle">Chart a new planet and its defining attributes.</p>
+    </div>
+  </div>
+
+  <form method="post" class="lcars-form__body">
     {% csrf_token %}
-    {{ form|crispy }}
-    <button type="submit" class="btn btn-primary">Save World</button>
+    {% if form %}
+      {% for hidden_field in form.hidden_fields %}
+        {{ hidden_field }}
+      {% endfor %}
+
+      {% if form.non_field_errors %}
+        <div class="lcars-form__errors">
+          {{ form.non_field_errors }}
+        </div>
+      {% endif %}
+
+      <div class="lcars-form__grid">
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Astrometrics</h2>
+          {% if form|has_field:'name' %}{{ form.name|as_crispy_field }}{% endif %}
+          {% if form|has_field:'system' %}{{ form.system|as_crispy_field }}{% endif %}
+          {% if form|has_field:'planet_class' %}{{ form.planet_class|as_crispy_field }}{% endif %}
+          {% if form|has_field:'moons' %}{{ form.moons|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Status</h2>
+          {% if form|has_field:'colonized' %}{{ form.colonized|as_crispy_field }}{% endif %}
+          {% if form|has_field:'terraformed' %}{{ form.terraformed|as_crispy_field }}{% endif %}
+          {% if form|has_field:'hidden' %}{{ form.hidden|as_crispy_field }}{% endif %}
+        </section>
+
+        <section class="lcars-form__section">
+          <h2 class="lcars-form__section-title">Lifeforms</h2>
+          {% if form|has_field:'contains_flora' %}{{ form.contains_flora|as_crispy_field }}{% endif %}
+          {% if form|has_field:'contains_fauna' %}{{ form.contains_fauna|as_crispy_field }}{% endif %}
+          {% if form|has_field:'contains_sentient_life' %}{{ form.contains_sentient_life|as_crispy_field }}{% endif %}
+        </section>
+
+        {% if form|has_field:'special_traits' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Notable Traits</h2>
+            {{ form.special_traits|as_crispy_field }}
+          </section>
+        {% endif %}
+
+        {% if form|has_field:'points_of_interest' %}
+          <section class="lcars-form__section lcars-form__section--full">
+            <h2 class="lcars-form__section-title">Points of Interest</h2>
+            {{ form.points_of_interest|as_crispy_field }}
+          </section>
+        {% endif %}
+      </div>
+    {% else %}
+      <p>World creation form unavailable.</p>
+    {% endif %}
+
+    <div class="lcars-form__actions">
+      <button type="submit" class="lcars-btn lcars-form__submit">Save World</button>
+    </div>
   </form>
-</div>
+</section>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a reusable LCARS form stylesheet and load it from the shared base template
- refactor the people add/edit experience to support differentiated layouts for crew and gallery records with modal skill selection
- rework the remaining add-object templates to use responsive LCARS sections and guard field rendering with a new `has_field` template filter

## Testing
- `python cataclysm/manage.py check` *(fails: ModuleNotFoundError: No module named 'cataclysm.cataclysm' in existing app imports)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_68db5820f0808323904d47d0b2982b62)