### PR TITLE
Fix armor view import path

### DIFF
--- a/cataclysm/armor/views.py
+++ b/cataclysm/armor/views.py
@@ -1,3 +1,3 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from cataclysm.views import StaticIndexView
 
 index = StaticIndexView.as_view(app_label="armor")


### PR DESCRIPTION
### Motivation
- The armor app referenced `cataclysm.cataclysm.views.StaticIndexView`, which is likely an incorrect or duplicated package path after a project restructure.
- The import needed to point to the top-level `cataclysm.views` package so `StaticIndexView` can be resolved.

### Description
- Updated the import in `cataclysm/armor/views.py` from `from cataclysm.cataclysm.views import StaticIndexView` to `from cataclysm.views import StaticIndexView`.
- This is a one-line change that leaves `index = StaticIndexView.as_view(app_label="armor")` intact.

### Testing
- No automated tests were run for this change.
- There were no test failures reported because no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695056480fe88323a970b9b01d1ce723)