### PR TITLE
Add catalog CRUD views for armor/events/factions/weapons/worlds and fix StaticIndexView import

### DIFF
--- a/cataclysm/adminflow/views.py
+++ b/cataclysm/adminflow/views.py
@@ -1,3 +1,3 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from cataclysm.views import StaticIndexView
 
 index = StaticIndexView.as_view(app_label="root")

--- a/cataclysm/armor/views.py
+++ b/cataclysm/armor/views.py
@@ -1,3 +1,23 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DetailView, ListView
 
-index = StaticIndexView.as_view(app_label="armor")
+from .models import Armor
+
+
+class ArmorListView(ListView):
+    model = Armor
+    template_name = "armor/armor.html"
+
+
+class ArmorDetailView(DetailView):
+    model = Armor
+    template_name = "armor/detail.html"
+
+
+class ArmorCreateView(CreateView):
+    model = Armor
+    fields = "__all__"
+    template_name = "armor/add_object.html"
+
+    def get_success_url(self):
+        return reverse_lazy("armor:detail", kwargs={"pk": self.object.pk})

--- a/cataclysm/events/views.py
+++ b/cataclysm/events/views.py
@@ -1,3 +1,23 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DetailView, ListView
 
-index = StaticIndexView.as_view(app_label="events")
+from .models import Event
+
+
+class EventListView(ListView):
+    model = Event
+    template_name = "events/events.html"
+
+
+class EventDetailView(DetailView):
+    model = Event
+    template_name = "events/detail.html"
+
+
+class EventCreateView(CreateView):
+    model = Event
+    fields = "__all__"
+    template_name = "events/add_object.html"
+
+    def get_success_url(self):
+        return reverse_lazy("events:detail", kwargs={"pk": self.object.pk})

--- a/cataclysm/factions/views.py
+++ b/cataclysm/factions/views.py
@@ -1,3 +1,23 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DetailView, ListView
 
-index = StaticIndexView.as_view(app_label="factions")
+from .models import Faction
+
+
+class FactionListView(ListView):
+    model = Faction
+    template_name = "factions/factions.html"
+
+
+class FactionDetailView(DetailView):
+    model = Faction
+    template_name = "factions/detail.html"
+
+
+class FactionCreateView(CreateView):
+    model = Faction
+    fields = "__all__"
+    template_name = "factions/add_object.html"
+
+    def get_success_url(self):
+        return reverse_lazy("factions:detail", kwargs={"pk": self.object.pk})

--- a/cataclysm/weapons/views.py
+++ b/cataclysm/weapons/views.py
@@ -1,3 +1,23 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DetailView, ListView
 
-index = StaticIndexView.as_view(app_label="weapons")
+from .models import Weapon
+
+
+class WeaponListView(ListView):
+    model = Weapon
+    template_name = "weapons/weapons.html"
+
+
+class WeaponDetailView(DetailView):
+    model = Weapon
+    template_name = "weapons/detail.html"
+
+
+class WeaponCreateView(CreateView):
+    model = Weapon
+    fields = "__all__"
+    template_name = "weapons/add_object.html"
+
+    def get_success_url(self):
+        return reverse_lazy("weapons:detail", kwargs={"pk": self.object.pk})

--- a/cataclysm/worlds/views.py
+++ b/cataclysm/worlds/views.py
@@ -1,3 +1,23 @@
-from cataclysm.cataclysm.views import StaticIndexView
+from django.urls import reverse_lazy
+from django.views.generic import CreateView, DetailView, ListView
 
-index = StaticIndexView.as_view(app_label="worlds")
+from .models import World
+
+
+class WorldListView(ListView):
+    model = World
+    template_name = "worlds/worlds.html"
+
+
+class WorldDetailView(DetailView):
+    model = World
+    template_name = "worlds/detail.html"
+
+
+class WorldCreateView(CreateView):
+    model = World
+    fields = "__all__"
+    template_name = "worlds/add_object.html"
+
+    def get_success_url(self):
+        return reverse_lazy("worlds:detail", kwargs={"pk": self.object.pk})


### PR DESCRIPTION
### Motivation
- URL configurations referenced class-based views like `ArmorListView` but many apps only exported a `StaticIndexView` placeholder, causing `AttributeError` at import time.
- The codebase had inconsistent import paths (e.g. `cataclysm.cataclysm.views` vs `cataclysm.views`) after a restructure which needed normalization.
- Provide minimal, model-backed CRUD views so the apps satisfy their URL patterns and render the existing templates.

### Description
- Replaced `StaticIndexView` placeholders with model-backed generic views (`ListView`, `DetailView`, `CreateView`) in `armor`, `events`, `factions`, `weapons`, and `worlds` by adding `*ListView`, `*DetailView`, and `*CreateView` classes wired to the corresponding models and templates.
- Updated `cataclysm/adminflow/views.py` to import `StaticIndexView` from `cataclysm.views` to match the project structure.
- Each `CreateView` uses `fields="__all__"` and implements `get_success_url` returning `reverse_lazy("<app>:detail", kwargs={"pk": self.object.pk})` to redirect to the created object's detail page.
- Templates already present in each app were reused and `template_name` was set to point at those templates (for example `armor/armor.html`, `events/events.html`).

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695056480fe88323a970b9b01d1ce723)