### PR TITLE
Fix species template path resolution

### DIFF
--- a/cataclysm/species/templates/species/species.html
+++ b/cataclysm/species/templates/species/species.html
@@ -1,0 +1,141 @@
+{% extends 'base.html' %}
+{% load mathfilters %}
+
+{% block content %}
+<div class="lcars-panel">
+    <div class="lcars-heading">
+        <span class="chip lcars-tab"></span>
+        <h2>{{ current_species.name }}</h2>
+    </div>
+    <div class="index_menu">
+        <a class="lcars-btn" href="{% url 'edit_species' current_species.id %}">Edit</a>
+    </div>
+    <div style="width: 100%;">
+        <table class="sci-fi-list">
+            <tr style="vertical-align: top;">
+                <td rowspan="2" style="vertical-align: middle; width: 250px;">
+                    {% if current_species.image %}
+                        <center><img src="{{ current_species.image.url }}" class="crew_image"></center>
+                    {% endif %}
+                </td>
+                <td colspan="3">
+                    <table style="vertical-align: top; width: 100%;">
+                        <th colspan="2" style="text-align: center;">Basic Info</th>
+                        <tr>
+                            <th>Home World</th>
+                            <td>{{ current_species.home_world|default:"-" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Size</th>
+                            <td>{{ current_species.get_size_display|default:"-" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Type</th>
+                            <td>{{ current_species.get_type_display|default:"-" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Accord Standing</th>
+                            <td>{{ current_species.get_accord_status_display|default:"-" }}</td>
+                        </tr>
+                    </table>
+                </td>
+                <td colspan="2">
+                    <table style="vertical-align: top; width: 100%;">
+                        <th colspan="2" style="text-align: center;">Environment</th>
+                        <tr>
+                            <th>Air</th>
+                            <td>{{ current_species.get_air_display|default:"-" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Gravity</th>
+                            <td>{{ current_species.get_gravity_display|default:"-" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Reproduction</th>
+                            <td>{{ current_species.get_reproduction_method_display|default:"-" }}</td>
+                        </tr>
+                        <tr>
+                            <th>Locomotion</th>
+                            <td>{{ current_species.get_locomotion_method_display|default:"-" }}</td>
+                        </tr>
+                    </table>
+                </td>
+            </tr>
+        </table>
+    </div>
+    <div>
+        <table class="sci-fi-list">
+            <tr>
+                <th>Strength</th>
+                <th>Toughness</th>
+                <th>Speed</th>
+                <th>Intelligence</th>
+                <th>Sleep (hrs)</th>
+                <th>Days w/o Food</th>
+                <th>Days w/o Water</th>
+            </tr>
+            <tr>
+                <td>
+                    <div class="rating-bar" style="width: {{ current_species.strength_rating|default:0|mul:10 }}%">&nbsp;{{ current_species.strength_rating|default:"-" }}</div>
+                </td>
+                <td>
+                    <div class="rating-bar" style="width: {{ current_species.toughness_rating|default:0|mul:10 }}%">&nbsp;{{ current_species.toughness_rating|default:"-" }}</div>
+                </td>
+                <td>
+                    <div class="rating-bar" style="width: {{ current_species.speed_rating|default:0|mul:10 }}%">&nbsp;{{ current_species.speed_rating|default:"-" }}</div>
+                </td>
+                <td>
+                    <div class="rating-bar" style="width: {{ current_species.intelligence_rating|default:0|mul:10 }}%">&nbsp;{{ current_species.intelligence_rating|default:"-" }}</div>
+                </td>
+                <td>{{ current_species.hours_of_sleep|default:"-" }}</td>
+                <td>{{ current_species.days_without_food|default:"-" }}</td>
+                <td>{{ current_species.days_without_water|default:"-" }}</td>
+            </tr>
+        </table>
+    </div>
+    <div>
+        <table class="sci-fi-list">
+            <tr>
+                <th class="boolean">Natural Weapons</th>
+                <th class="boolean">Natural Armor</th>
+                <th class="boolean">Can Fly</th>
+                <th class="boolean">Aquatic</th>
+                <th class="boolean">Amphibious</th>
+                <th class="boolean">Telepathic</th>
+                <th class="boolean">Psionic</th>
+            </tr>
+            <tr>
+                <td class="boolean-cell {% if current_species.natural_weapons %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.natural_weapons }}</td>
+                <td class="boolean-cell {% if current_species.natural_armor %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.natural_armor }}</td>
+                <td class="boolean-cell {% if current_species.can_fly %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.can_fly }}</td>
+                <td class="boolean-cell {% if current_species.aquatic %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.aquatic }}</td>
+                <td class="boolean-cell {% if current_species.amphibious %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.amphibious }}</td>
+                <td class="boolean-cell {% if current_species.telepathic %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.telepathic }}</td>
+                <td class="boolean-cell {% if current_species.psionic %}boolean-true{% else %}boolean-false{% endif %}">{{ current_species.psionic }}</td>
+            </tr>
+        </table>
+    </div>
+    <div>
+        <table class="sci-fi-list">
+            <tr>
+                <th>Background</th>
+            </tr>
+            <tr>
+                <td>{{ current_species.background|default:"-" }}</td>
+            </tr>
+            <tr>
+                <th>Sociology</th>
+            </tr>
+            <tr>
+                <td>{{ current_species.sociology|default:"-" }}</td>
+            </tr>
+            <tr>
+                <th>Physiology</th>
+            </tr>
+            <tr>
+                <td>{{ current_species.physiology|default:"-" }}</td>
+            </tr>
+        </table>
+    </div>
+</div>
+{% endblock %}

--- a/cataclysm/species/views.py
+++ b/cataclysm/species/views.py
@@ -49,7 +49,7 @@ def species_page(request, id):
     context = {
         'current_species': current_species,
     }
-    return render(request, 'species.html', context)
+    return render(request, 'species/species.html', context)
 
 def add(request):
     if request.method == 'POST':


### PR DESCRIPTION
### Motivation
- A `TemplateDoesNotExist: species.html` error occurred when rendering the species detail page because the template was not located where Django would discover it.
- Ensure the species detail template is namespaced under the app to match Django app template discovery conventions.
- Keep the view and template paths consistent so the detail page can render correctly.

### Description
- Moved the species detail template into `cataclysm/species/templates/species/species.html` so it is namespaced under the app.
- Updated the `species_page` view in `cataclysm/species/views.py` to call `render(request, 'species/species.html', context)` instead of `species.html`.
- No other functional changes were introduced.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956fedb59c08323b4a1aab7a9745c6c)