### PR TITLE
Standardize template headers with shared base header

### DIFF
--- a/cataclysm/armor/templates/armor/add_object.html
+++ b/cataclysm/armor/templates/armor/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}Add Armor{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Catalog defensive gear with a streamlined LCARS workflow.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Armor</h1>
-      <p class="lcars-form__subtitle">Catalog defensive gear with a streamlined LCARS workflow.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/armor/templates/armor/armor.html
+++ b/cataclysm/armor/templates/armor/armor.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Armor{% endblock %}
+{% block header_actions %}
+  <a class="lcars-btn" href="{% url 'armor:add' %}">Add Armor</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-  <div class="list-header index_menu">
-    <h1 class="app_name">Armor</h1>
-    <a class="btn btn-primary" href="{% url 'armor:add' %}">Add Armor</a>
-  </div>
   <table class="sci-fi-list" style="margin-top:12px; width:100%;">
     <thead>
       <tr>

--- a/cataclysm/armor/templates/armor/detail.html
+++ b/cataclysm/armor/templates/armor/detail.html
@@ -1,9 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
+{% block header_title %}{{ object.name|default:'Armor' }}{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'armor:index' %}" class="lcars-btn">Back</a>
+{% endblock %}
 {% block content %}
 <div class="container">
-  <h1>{{ object.name|default:'Armor' }}</h1>
   <p>Type: {{ object.armor_type|default:'-' }}</p>
   <p>Base AC: {{ object.base_armor_class|default:'-' }}</p>
-  <a href="{% url 'armor:index' %}">Back</a>
 </div>
 {% endblock %}

--- a/cataclysm/events/templates/events/add_object.html
+++ b/cataclysm/events/templates/events/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}Add Event{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Log a pivotal happening in the campaign timeline.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Event</h1>
-      <p class="lcars-form__subtitle">Log a pivotal happening in the campaign timeline.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/events/templates/events/detail.html
+++ b/cataclysm/events/templates/events/detail.html
@@ -1,9 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
+{% block header_title %}{{ object.name|default:'Event' }}{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'events:index' %}" class="lcars-btn">Back</a>
+{% endblock %}
 {% block content %}
 <div class="container">
-  <h1>{{ object.name|default:'Event' }}</h1>
   <p>Date: {{ object.date }}</p>
   <p>Location: {{ object.location }}</p>
-  <a href="{% url 'events:index' %}">Back</a>
 </div>
 {% endblock %}

--- a/cataclysm/events/templates/events/events.html
+++ b/cataclysm/events/templates/events/events.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Events{% endblock %}
+{% block header_actions %}
+  <a class="lcars-btn" href="{% url 'events:add' %}">Add Event</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-  <div class="list-header index_menu">
-    <h1 class="app_name">Events</h1>
-    <a class="btn btn-primary" href="{% url 'events:add' %}">Add Event</a>
-  </div>
   <table class="sci-fi-list" style="margin-top:12px; width:100%;">
     <thead>
       <tr>

--- a/cataclysm/factions/templates/factions/add_object.html
+++ b/cataclysm/factions/templates/factions/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}Add Faction{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Define the organization and its influence.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Faction</h1>
-      <p class="lcars-form__subtitle">Define the organization and its influence.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/factions/templates/factions/detail.html
+++ b/cataclysm/factions/templates/factions/detail.html
@@ -1,8 +1,10 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
+{% block header_title %}{{ object.name|default:'Faction' }}{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'factions:index' %}" class="lcars-btn">Back</a>
+{% endblock %}
 {% block content %}
 <div class="container">
-  <h1>{{ object.name|default:'Faction' }}</h1>
   <p>{{ object.description|default:'No description.' }}</p>
-  <a href="{% url 'factions:index' %}">Back</a>
 </div>
 {% endblock %}

--- a/cataclysm/factions/templates/factions/factions.html
+++ b/cataclysm/factions/templates/factions/factions.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Factions{% endblock %}
+{% block header_actions %}
+	<a class="lcars-btn" href="{% url 'factions:add' %}">Add Faction</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-	<div class="list-header index_menu">
-		<h1 class="app_name">Factions</h1>
-		<a class="btn btn-primary" href="{% url 'factions:add' %}">Add Faction</a>
-	</div>
 	<table class="sci-fi-list" style="margin-top:12px; width:100%;">
 		<thead>
 			<tr>

--- a/cataclysm/landing/templates/base.html
+++ b/cataclysm/landing/templates/base.html
@@ -11,6 +11,7 @@
 <body>
     {% include 'navbar.html' %}
     <div class="container">
+        {% block header %}{% endblock %}
         {% block content %}{% endblock %}
     </div>
 </body>

--- a/cataclysm/landing/templates/base_with_header.html
+++ b/cataclysm/landing/templates/base_with_header.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+
+{% block header %}
+  <div class="lcars-page-header">
+    <div class="lcars-page-header__title">
+      <span class="chip lcars-tab" aria-hidden="true"></span>
+      <div>
+        <h1 class="lcars-page-header__heading">{% block header_title %}{% endblock %}</h1>
+        {% block header_subtitle %}{% endblock %}
+      </div>
+    </div>
+    <div class="lcars-page-header__actions">
+      {% block header_actions %}{% endblock %}
+    </div>
+  </div>
+{% endblock %}

--- a/cataclysm/mindmaps/templates/mindmaps/mindmap_detail.html
+++ b/cataclysm/mindmaps/templates/mindmaps/mindmap_detail.html
@@ -1,9 +1,12 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}{{ mindmap.title }}{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'mindmap_edit' mindmap.pk %}" class="lcars-btn">Edit Mind Map</a>
+  <a href="{% url 'mindmapnode_add' %}" class="lcars-btn">Add Node</a>
+{% endblock %}
 {% block content %}
-<h1>{{ mindmap.title }}</h1>
 <p>{{ mindmap.description }}</p>
 <p>Created: {{ mindmap.created_at }} | Updated: {{ mindmap.updated_at }}</p>
-<a href="{% url 'mindmap_edit' mindmap.pk %}" class="btn btn-secondary">Edit Mind Map</a>
 <h2>Nodes</h2>
 <ul>
   {% for node in mindmap.nodes.all %}
@@ -12,5 +15,4 @@
     <li>No nodes yet.</li>
   {% endfor %}
 </ul>
-<a href="{% url 'mindmapnode_add' %}" class="btn btn-primary">Add Node</a>
 {% endblock %}

--- a/cataclysm/mindmaps/templates/mindmaps/mindmap_form.html
+++ b/cataclysm/mindmaps/templates/mindmaps/mindmap_form.html
@@ -1,9 +1,9 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
 {% load crispy_forms_tags %}
+{% block header_title %}{% if form.instance.pk %}Edit Mind Map{% else %}Add Mind Map{% endif %}{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="sci-fi-form-container">
-  <h1 style="text-align:center; letter-spacing: 0.12em; color: #0ff; text-shadow: 0 0 10px #0ff, 0 0 2px #fff; font-size:2.2rem;">{% if form.instance.pk %}Edit Mind Map{% else %}Add Mind Map{% endif %}</h1>
   <form method="post">
     {% csrf_token %}
     <div class="sci-fi-form-grid" style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 2.5em 3em; align-items: start;">

--- a/cataclysm/mindmaps/templates/mindmaps/mindmap_index.html
+++ b/cataclysm/mindmaps/templates/mindmaps/mindmap_index.html
@@ -1,7 +1,9 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Mind Maps{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'mindmap_add' %}" class="lcars-btn">Add Mind Map</a>
+{% endblock %}
 {% block content %}
-<h1>Mind Maps</h1>
-<a href="{% url 'mindmap_add' %}" class="btn btn-primary">Add Mind Map</a>
 <ul>
   {% for mindmap in mindmaps %}
     <li><a href="{% url 'mindmap_detail' mindmap.pk %}">{{ mindmap.title }}</a></li>

--- a/cataclysm/mindmaps/templates/mindmaps/mindmapnode_form.html
+++ b/cataclysm/mindmaps/templates/mindmaps/mindmapnode_form.html
@@ -1,9 +1,9 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
 {% load crispy_forms_tags %}
+{% block header_title %}{% if form.instance.pk %}Edit Node{% else %}Add Node{% endif %}{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="sci-fi-form-container">
-  <h1 style="text-align:center; letter-spacing: 0.12em; color: #0ff; text-shadow: 0 0 10px #0ff, 0 0 2px #fff; font-size:2.2rem;">{% if form.instance.pk %}Edit Node{% else %}Add Node{% endif %}</h1>
   <form method="post">
     {% csrf_token %}
     <div class="sci-fi-form-grid" style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 2.5em 3em; align-items: start;">

--- a/cataclysm/mindmaps/templates/mindmaps/mindmaps.html
+++ b/cataclysm/mindmaps/templates/mindmaps/mindmaps.html
@@ -1,7 +1,9 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Mind Maps{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'mindmap_add' %}" class="lcars-btn">Add Mind Map</a>
+{% endblock %}
 {% block content %}
-<h1>Mind Maps</h1>
-<a href="{% url 'mindmap_add' %}" class="btn btn-primary">Add Mind Map</a>
 <ul>
   {% for mindmap in mindmaps %}
     <li><a href="{% url 'mindmap_detail' mindmap.pk %}">{{ mindmap.title }}</a></li>

--- a/cataclysm/party/templates/party/party.html
+++ b/cataclysm/party/templates/party/party.html
@@ -1,17 +1,17 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load static %}
 {% load mathfilters %}
 {% load group_check %}
 
 <link rel="stylesheet" href="/static/css/default.css">
 
+{% block header_title %}{{ current_party.name }}{% endblock %}
+{% block header_actions %}
+	<a class="lcars-btn" href="{% url 'edit_party' current_party.pk %}">Edit</a>
+	<a class="lcars-btn" href="{% url 'add_party_images' current_party.pk %}">Add Images</a>
+{% endblock %}
 {% block content %}
 <div class="lcars-panel">
-	<div class="lcars-heading">
-		<span class="chip lcars-tab"></span>
-		<h2>{{ current_party.name }}</h2>
-	</div>
-	<div class="index_menu"><a class="lcars-btn" href="{% url 'edit_party' current_party.pk %}">Edit</a> <a class="lcars-btn" href="{% url 'add_party_images' current_party.pk %}">Add Images</a></div>
 	<table style="width:100%; margin-top:20px;">
 		<!-- additional images and members are shown above -->
 	</table>

--- a/cataclysm/party/templates/party/party_form.html
+++ b/cataclysm/party/templates/party/party_form.html
@@ -1,14 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
 {% load crispy_forms_tags %}
 
+{% block header_title %}{% if party %}Edit Party{% else %}Add Party{% endif %}{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="lcars-panel">
   <div class="sci-fi-form-container">
-  <div class="lcars-heading" style="justify-content:center;">
-    <span class="chip lcars-tab"></span>
-    <h1 style="margin:0; font-size:2.2rem;">{% if party %}Edit Party{% else %}Add Party{% endif %}</h1>
-  </div>
   <form method="post">
     {% csrf_token %}
     <div class="sci-fi-form-grid" style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 2.5em 3em; align-items: start;">

--- a/cataclysm/party/templates/party/party_index.html
+++ b/cataclysm/party/templates/party/party_index.html
@@ -1,15 +1,14 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load mathfilters %}
 {% load group_check %}
 
+{% block header_title %}Party Index{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'add_party' %}">Add Party</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-    <div class="index_menu">
-        <h1 class="app_name">Party Index</h1>
-        <a class="btn btn-primary" href="{% url 'add_party' %}">Add Party</a>
-    </div>
-
     <table class="sci-fi-list">
         <thead>
             <tr>

--- a/cataclysm/people/templates/add_object.html
+++ b/cataclysm/people/templates/add_object.html
@@ -1,33 +1,25 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}
+  {% if form_mode == 'person' %}
+    Add Crew Member
+  {% elif form_mode == 'person_image' %}
+    Attach Visual Record
+  {% else %}
+    Add Record
+  {% endif %}
+{% endblock %}
+{% block header_subtitle %}
+  {% if form_mode == 'person' %}
+    <p class="lcars-page-header__subtitle">Document a new operative for the Cataclysm roster.</p>
+  {% elif form_mode == 'person_image' %}
+    <p class="lcars-page-header__subtitle">Upload supporting imagery for an existing crew member.</p>
+  {% else %}
+    <p class="lcars-page-header__subtitle">Provide the details below to expand the database.</p>
+  {% endif %}
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  {% if form_mode == 'person' %}
-    <div class="lcars-form__header">
-      <span class="lcars-form__chip" aria-hidden="true"></span>
-      <div>
-        <h1 class="lcars-form__title">Add Crew Member</h1>
-        <p class="lcars-form__subtitle">Document a new operative for the Cataclysm roster.</p>
-      </div>
-    </div>
-  {% elif form_mode == 'person_image' %}
-    <div class="lcars-form__header">
-      <span class="lcars-form__chip" aria-hidden="true"></span>
-      <div>
-        <h1 class="lcars-form__title">Attach Visual Record</h1>
-        <p class="lcars-form__subtitle">Upload supporting imagery for an existing crew member.</p>
-      </div>
-    </div>
-  {% else %}
-    <div class="lcars-form__header">
-      <span class="lcars-form__chip" aria-hidden="true"></span>
-      <div>
-        <h1 class="lcars-form__title">Add Record</h1>
-        <p class="lcars-form__subtitle">Provide the details below to expand the database.</p>
-      </div>
-    </div>
-  {% endif %}
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% for hidden_field in form.hidden_fields %}

--- a/cataclysm/people/templates/people_index.html
+++ b/cataclysm/people/templates/people_index.html
@@ -1,15 +1,14 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load mathfilters %}
 {% load group_check %}
 
+{% block header_title %}People Index{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'add_person' %}">Add Person</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-    <div class="index_menu">
-        <h1 class="app_name">People Index</h1>
-        <a class="btn btn-primary" href="{% url 'add_person' %}">Add Person</a>
-    </div>
-
     <div class="column-buttons ">
         <table class="toggle-table">
             <tr>

--- a/cataclysm/people/templates/person.html
+++ b/cataclysm/people/templates/person.html
@@ -1,13 +1,12 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load mathfilters %}
 {% load group_check %}
+{% block header_title %}{{ current_person.name }}{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'edit_person' current_person.id%}">Edit</a>
+{% endblock %}
 {% block content %}
 <div class="lcars-panel">
-    <div class="lcars-heading">
-        <span class="chip lcars-tab"></span>
-        <h2>{{ current_person.name }}</h2>
-    </div>
-    <div class="index_menu"><a class="lcars-btn" href="{% url 'edit_person' current_person.id%}">Edit</a></div>
     <div style="width: 100%;">
         <table class="sci-fi-list">
             <tr style="vertical-align: top;">

--- a/cataclysm/ships/templates/ships/add_object.html
+++ b/cataclysm/ships/templates/ships/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags %}
+{% block header_title %}Add Starship{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Commission a new vessel into the fleet registry.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Starship</h1>
-      <p class="lcars-form__subtitle">Commission a new vessel into the fleet registry.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/ships/templates/ships/ships.html
+++ b/cataclysm/ships/templates/ships/ships.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Starships{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'ships:add' %}">Add Starship</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-    <div class="list-header index_menu">
-        <h1 class="app_name">Starships</h1>
-        <a class="btn btn-primary" href="{% url 'ships:add' %}">Add Starship</a>
-    </div>
   <table class="sci-fi-list" style="margin-top:12px; width:100%;">
     <thead>
       <tr>

--- a/cataclysm/species/templates/species.html
+++ b/cataclysm/species/templates/species.html
@@ -1,15 +1,12 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load mathfilters %}
 
+{% block header_title %}{{ current_species.name }}{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'edit_species' current_species.id %}">Edit</a>
+{% endblock %}
 {% block content %}
 <div class="lcars-panel">
-    <div class="lcars-heading">
-        <span class="chip lcars-tab"></span>
-        <h2>{{ current_species.name }}</h2>
-    </div>
-    <div class="index_menu">
-        <a class="lcars-btn" href="{% url 'edit_species' current_species.id %}">Edit</a>
-    </div>
     <div style="width: 100%;">
         <table class="sci-fi-list">
             <tr style="vertical-align: top;">

--- a/cataclysm/species/templates/species/add_object.html
+++ b/cataclysm/species/templates/species/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}Add Species{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Capture the traits of a new civilization for the LCARS archive.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Species</h1>
-      <p class="lcars-form__subtitle">Capture the traits of a new civilization for the LCARS archive.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% for hidden_field in form.hidden_fields %}

--- a/cataclysm/species/templates/species/species.html
+++ b/cataclysm/species/templates/species/species.html
@@ -1,15 +1,12 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load mathfilters %}
 
+{% block header_title %}{{ current_species.name }}{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'edit_species' current_species.id %}">Edit</a>
+{% endblock %}
 {% block content %}
 <div class="lcars-panel">
-    <div class="lcars-heading">
-        <span class="chip lcars-tab"></span>
-        <h2>{{ current_species.name }}</h2>
-    </div>
-    <div class="index_menu">
-        <a class="lcars-btn" href="{% url 'edit_species' current_species.id %}">Edit</a>
-    </div>
     <div style="width: 100%;">
         <table class="sci-fi-list">
             <tr style="vertical-align: top;">

--- a/cataclysm/species/templates/species_index.html
+++ b/cataclysm/species/templates/species_index.html
@@ -1,14 +1,14 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load mathfilters %}
 {% load group_check %}
 
+{% block header_title %}Species Index{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'add' %}">Add Species</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-    <div class="list-header index_menu">
-        <h1 class="app_name">Species Index</h1>
-        <a class="btn btn-primary" href="{% url 'add' %}">Add Species</a>
-    </div>
     <table class="sci-fi-list">
         <thead>
             <tr>

--- a/cataclysm/static/css/lcars.css
+++ b/cataclysm/static/css/lcars.css
@@ -57,6 +57,41 @@ body{
   padding-top:2px;
 }
 
+.lcars-page-header{
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:1.5rem;
+  margin: 1.2rem 0;
+  flex-wrap:wrap;
+}
+
+.lcars-page-header__title{
+  display:flex;
+  align-items:center;
+  gap:1rem;
+}
+
+.lcars-page-header__heading{
+  margin:0;
+  font-size:clamp(1.5rem, 3vw, 2.3rem);
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+
+.lcars-page-header__subtitle{
+  margin:.35rem 0 0;
+  color:rgba(255,255,255,0.7);
+  font-size:clamp(0.95rem, 2vw, 1.1rem);
+  letter-spacing:.04em;
+}
+
+.lcars-page-header__actions{
+  display:flex;
+  gap:.75rem;
+  flex-wrap:wrap;
+}
+
 /* Buttons */
 .lcars-btn{
   background: linear-gradient(90deg,var(--lcars-accent-2), #0077aa);

--- a/cataclysm/vehicles/templates/vehicles/add_object.html
+++ b/cataclysm/vehicles/templates/vehicles/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags %}
+{% block header_title %}Add Vehicle{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Register a new ground or atmospheric craft.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Vehicle</h1>
-      <p class="lcars-form__subtitle">Register a new ground or atmospheric craft.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/vehicles/templates/vehicles/vehicles.html
+++ b/cataclysm/vehicles/templates/vehicles/vehicles.html
@@ -1,11 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
+{% block header_title %}Vehicles{% endblock %}
+{% block header_actions %}
+    <a class="lcars-btn" href="{% url 'vehicles:add' %}">Add Vehicle</a>
+{% endblock %}
 {% block content %}
 <link rel="stylesheet" href="/static/css/sci-fi-form.css">
 <div class="container" style="margin-top:20px;">
-    <div class="list-header index_menu">
-        <h1 class="app_name">Vehicles</h1>
-        <a class="btn btn-primary" href="{% url 'vehicles:add' %}">Add Vehicle</a>
-    </div>
   <table class="sci-fi-list" style="margin-top:12px; width:100%;">
     <thead>
       <tr>

--- a/cataclysm/weapons/templates/weapons/add_object.html
+++ b/cataclysm/weapons/templates/weapons/add_object.html
@@ -1,15 +1,11 @@
-{% extends "base.html" %}
+{% extends "base_with_header.html" %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}Add Weapon{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Record the specifications for a new arsenal entry.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add Weapon</h1>
-      <p class="lcars-form__subtitle">Record the specifications for a new arsenal entry.</p>
-    </div>
-  </div>
-
   <form method="post" enctype="multipart/form-data" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/weapons/templates/weapons/detail.html
+++ b/cataclysm/weapons/templates/weapons/detail.html
@@ -1,8 +1,10 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
+{% block header_title %}{{ object.name|default:'Weapon' }}{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'weapons:index' %}" class="lcars-btn">Back</a>
+{% endblock %}
 {% block content %}
 <div class="container">
-  <h1>{{ object.name|default:'Weapon' }}</h1>
   <p>{{ object.description|default:'No description available.' }}</p>
-  <a href="{% url 'weapons:index' %}">Back</a>
 </div>
 {% endblock %}

--- a/cataclysm/weapons/templates/weapons/weapons.html
+++ b/cataclysm/weapons/templates/weapons/weapons.html
@@ -1,10 +1,10 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load static %}
+{% block header_title %}Weapons{% endblock %}
+{% block header_actions %}
+	<a href="{% url 'weapons:add' %}" class="lcars-btn">Add Weapon</a>
+{% endblock %}
 {% block content %}
-<div class="list-header index_menu">
-	<h1 class="app_name">Weapons</h1>
-	<a href="{% url 'weapons:add' %}" class="btn btn-primary">Add Weapon</a>
-</div>
 <table class="table table-striped sci-fi-table">
 	<thead>
 		<tr>

--- a/cataclysm/worlds/templates/worlds/add_object.html
+++ b/cataclysm/worlds/templates/worlds/add_object.html
@@ -1,15 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
 {% load crispy_forms_tags custom_filters %}
+{% block header_title %}Add World{% endblock %}
+{% block header_subtitle %}
+  <p class="lcars-page-header__subtitle">Chart a new planet and its defining attributes.</p>
+{% endblock %}
 {% block content %}
 <section class="lcars-panel lcars-form">
-  <div class="lcars-form__header">
-    <span class="lcars-form__chip" aria-hidden="true"></span>
-    <div>
-      <h1 class="lcars-form__title">Add World</h1>
-      <p class="lcars-form__subtitle">Chart a new planet and its defining attributes.</p>
-    </div>
-  </div>
-
   <form method="post" class="lcars-form__body">
     {% csrf_token %}
     {% if form %}

--- a/cataclysm/worlds/templates/worlds/detail.html
+++ b/cataclysm/worlds/templates/worlds/detail.html
@@ -1,9 +1,11 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
+{% block header_title %}{{ object.name|default:'World' }}{% endblock %}
+{% block header_actions %}
+  <a href="{% url 'worlds:index' %}" class="lcars-btn">Back</a>
+{% endblock %}
 {% block content %}
 <div class="container">
-  <h1>{{ object.name|default:'World' }}</h1>
   <p>System: {{ object.system|default:'-' }}</p>
   <p>Planet class: {{ object.planet_class|default:'-' }}</p>
-  <a href="{% url 'worlds:index' %}">Back</a>
 </div>
 {% endblock %}

--- a/cataclysm/worlds/templates/worlds/worlds.html
+++ b/cataclysm/worlds/templates/worlds/worlds.html
@@ -1,9 +1,9 @@
-{% extends 'base.html' %}
+{% extends 'base_with_header.html' %}
+{% block header_title %}Worlds{% endblock %}
+{% block header_actions %}
+	<a href="{% url 'worlds:add' %}" class="lcars-btn">Add World</a>
+{% endblock %}
 {% block content %}
-<div class="list-header index_menu">
-	<h1 class="app_name">Worlds</h1>
-	<a href="{% url 'worlds:add' %}" class="btn btn-primary">Add World</a>
-</div>
 <table class="table table-hover sci-fi-table">
 	<thead>
 		<tr>


### PR DESCRIPTION
### Motivation
- Provide a consistent page header across the app to avoid duplicated header markup in each template.  
- Move action buttons and titles into a single header block so pages share the same structure and styling.  
- Reduce template duplication by introducing a small layout fragment that pages can override with `header_title`, `header_subtitle`, and `header_actions`.  

### Description
- Add a new layout `cataclysm/landing/templates/base_with_header.html` and expose a `header` block in `cataclysm/landing/templates/base.html`.  
- Refactor many templates to extend `base_with_header.html` and supply `header_title`, optional `header_subtitle`, and `header_actions`, removing their inline header markup (examples include `weapons`, `armor`, `vehicles`, `species`, `people`, `factions`, `worlds`, `events`, `ships`, `mindmaps`, `party`, and more).  
- Introduce unified header styles in `cataclysm/static/css/lcars.css` with new rules for `.lcars-page-header`, `.lcars-page-header__title`, `.lcars-page-header__heading`, `.lcars-page-header__subtitle`, and `.lcars-page-header__actions`.  
- Clean up form and detail templates to rely on the shared header and simplified content blocks.  

### Testing
- Started the development server with `python manage.py runserver`, which launched but reported unapplied migrations (server booted).  
- Attempted an automated Playwright screenshot to visually verify the header, but the Chromium process crashed (SIGSEGV) in the container so the capture did not complete.  
- Performed repository searches (e.g. `rg`) to confirm templates now extend `base_with_header.html` and include `header_title` blocks.  
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69571631700c8323a417c30034e239f4)