### PR TITLE
Streamline fonts to Roddenberry (StarTrekFont)

### DIFF
--- a/cataclysm/static/css/default.css
+++ b/cataclysm/static/css/default.css
@@ -2,38 +2,6 @@
     font-family: 'StarTrekFont';
     src: url('/static/fonts/Roddenberry.ttf') format('truetype');
 }
-@font-face {
-    font-family: 'AlienRavager';
-    src: url('/static/fonts/AlienRavager.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'AlienRavagerItalic';
-    src: url('/static/fonts/AlienRavagerItalic.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'Rebellion';
-    src: url('/static/fonts/Rebellion.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'RebellionItalic';
-    src: url('/static/fonts/RebellionItalic.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'StarTrekFuture';
-    src: url('/static/fonts/StarTrekFuture.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'StartrekenterprisefutureItalic';
-    src: url('/static/fonts/StartrekenterprisefutureItalic.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'Stacker';
-    src: url('static/fonts/Stacker.ttf') format('truetype');
-}
-@font-face {
-    font-family: 'GoodOT';
-    src: url('/static/fonts/GoodOT.otf') format('opentype');
-}
 /* Dark mode styles */
 body {
     background-image: url('../images/background.png');
@@ -42,6 +10,7 @@ body {
     background-size: 100% 100%;
     background-color: var(--lcars-bg, #111); /* LCARS background (fallback) */
     color: var(--lcars-text, #fff); /* Use LCARS text color when available */
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
 }
 
 /* Example styles for links in dark mode */
@@ -99,13 +68,13 @@ nav.main a:hover {
 h1.app_name {
     color: var(--lcars-panel, #ff9900); /* LCARS panel color */
     text-align: center;
-    font-family: 'Rebellion';
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     font-size: 72px;
 }
 h2.welcome {
     color: #ff9900; /* Gold text color */
     text-align: center;
-    font-family: 'Rebellion';
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     font-size: 24px;
 }
 p.app_description {
@@ -113,7 +82,7 @@ p.app_description {
     padding: 25px;
     color: var(--lcars-panel, #FFE81F);
     text-align: center;
-    font-family: 'GoodOT';
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     font-size: 24px;
 }
 
@@ -251,7 +220,7 @@ div button {
 .sci-fi-list {
     border-collapse: collapse;
     width: 100%;
-    font-family: GoodOT;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     background-color: #333; /* Dark background color */
     color: #fff; /* Light text color */
 }
@@ -259,7 +228,7 @@ div button {
 .sci-fi-list-species {
     border-collapse: collapse;
     width: 80%;
-    font-family: GoodOT;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     background-color: #333; /* Dark background color */
     color: #fff; /* Light text color */
 }
@@ -309,7 +278,7 @@ div button {
 }
 
 .toggle-table th {
-    font-family: GoodOT;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     font-size: 24px;
     color: #fff;
     padding-left: 25px;
@@ -317,7 +286,7 @@ div button {
 }
 
 .toggle-table td {
-    font-family: GoodOT;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     font-size: 24px;
     color: #fff;
     margin-right: 10px;
@@ -366,12 +335,12 @@ div button {
     color: black;
     text-align: left;
     font-weight: bold;
-    font-family: GoodOT;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
 }
 .index_menu {
     color: #ff9900; /* Gold text color */
     text-align: center;
-    font-family: 'Rebellion';
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     font-size: 24px;
     margin-bottom: 20px;
     padding-bottom: 20px;

--- a/cataclysm/static/css/lcars.css
+++ b/cataclysm/static/css/lcars.css
@@ -13,7 +13,7 @@
 body{
   background: linear-gradient(180deg, #071021 0%, #0b0b1a 100%);
   color: var(--lcars-text);
-  font-family: 'StarTrekFuture', 'Rebellion', 'Segoe UI', Arial, sans-serif;
+  font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
 }
 
 /* LCARS top bar */

--- a/cataclysm/static/css/sci-fi-form.css
+++ b/cataclysm/static/css/sci-fi-form.css
@@ -1,3 +1,8 @@
+@font-face {
+    font-family: 'StarTrekFont';
+    src: url('/static/fonts/Roddenberry.ttf') format('truetype');
+}
+
 /* Sci-Fi Form Styles - reusable for all forms */
 .sci-fi-form-container {
     max-width: 80%;
@@ -8,7 +13,7 @@
     box-shadow: none;
     padding: 2.5em 2vw 2em 2vw;
     color: var(--lcars-text, #fff);
-    font-family: 'Orbitron', 'Segoe UI', Arial, sans-serif;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     border: 2.5px solid var(--lcars-panel, #00f0ff);
 }
 .sci-fi-form-container h1 {
@@ -39,7 +44,7 @@
     border: 1.5px solid var(--lcars-accent-2, #0ff);
     border-radius: 0.35em;
     margin-bottom: 0.7em;
-    font-family: 'Orbitron', 'Segoe UI', Arial, sans-serif;
+    font-family: 'StarTrekFont', 'Segoe UI', Arial, sans-serif;
     box-shadow: inset 0 0 6px rgba(0,200,255,0.06);
     font-size: 1em;
 }


### PR DESCRIPTION
### Motivation
- Unify site typography to a single sci‑fi themed font for consistent appearance across pages.
- Ensure pages that only load isolated CSS (e.g. form styles) still have the Roddenberry font available.

### Description
- Removed multiple legacy `@font-face` declarations from `cataclysm/static/css/default.css` and set the global body font to the Roddenberry alias `StarTrekFont`.
- Replaced other font-family usages (`Rebellion`, `GoodOT`, `Orbitron`, `StarTrekFuture`, etc.) with `StarTrekFont` in `cataclysm/static/css/default.css`, `cataclysm/static/css/lcars.css`, and `cataclysm/static/css/sci-fi-form.css`.
- Embedded the Roddenberry `@font-face` into `cataclysm/static/css/sci-fi-form.css` so forms that load only that stylesheet still render correctly.
- Modified three files: `cataclysm/static/css/default.css`, `cataclysm/static/css/lcars.css`, and `cataclysm/static/css/sci-fi-form.css`.

### Testing
- Started the development server with `python manage.py runserver`, and the server process launched (system checks ran; migration warnings were reported). 
- Captured a page screenshot using an automated Playwright script and the navigation completed and produced `artifacts/roddenberry-fonts.png`.
- No automated unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69573ddf26748323b3fd151caf8604f6)